### PR TITLE
[Sprint #2] init groups app and update user model

### DIFF
--- a/buildbuild/groups/README
+++ b/buildbuild/groups/README
@@ -1,0 +1,8 @@
+* group modeling
+** user_id
+** groupname
+** additional info?
+
+* user-group relation modeling
+** user_id
+** group_id

--- a/buildbuild/groups/admin.py
+++ b/buildbuild/groups/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/buildbuild/groups/models.py
+++ b/buildbuild/groups/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/buildbuild/groups/tests.py
+++ b/buildbuild/groups/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/buildbuild/groups/views.py
+++ b/buildbuild/groups/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/buildbuild/users/models.py
+++ b/buildbuild/users/models.py
@@ -10,7 +10,6 @@ class UserManager(BaseUserManager):
         if not email:
             raise ValueError("User must have an email address")
 
-
         validate_email(email)
         self.validate_password(password)
 
@@ -26,9 +25,6 @@ class UserManager(BaseUserManager):
 
         if "is_admin" in kwargs and kwargs["is_admin"]:
             user.is_admin = True
-
-        if "is_org_admin" in kwargs and kwargs["is_org_admin"]:
-            user.is_org_admin = True
 
         user.save(using = self._db)
         return user
@@ -50,7 +46,6 @@ class User(AbstractBaseUser):
 
     is_active = models.BooleanField(default=True)
     is_admin = models.BooleanField(default=False)
-    is_org_admin = models.BooleanField(default=False)
     phonenumber = models.CharField(max_length=18)
 
     # custom UserManager

--- a/buildbuild/users/tests.py
+++ b/buildbuild/users/tests.py
@@ -66,22 +66,6 @@ class UserModelTest(TestCase):
                 )
         self.assertTrue(user.is_admin)
 
-    # is_org_admin
-    def test_user_with_no_is_org_admin_args_shoud_not_be_org_admin(self):
-        user = User.users.create_user(
-                email = self.valid_email,
-                password = self.valid_password,
-                )
-        self.assertFalse(user.is_org_admin)
-
-    def test_user_with_is_org_admin_args_shoud_be_org_admin(self):
-        user = User.users.create_user(
-                email = self.valid_email,
-                password = self.valid_password,
-                is_org_admin = True,
-                )
-        self.assertTrue(user.is_org_admin)
-
     # is_active
     def test_user_with_no_is_active_args_shoud_be_active(self):
         user = User.users.create_user(


### PR DESCRIPTION
## Development Date
- 140731 - 140806 ( 7 days )
## Changes from previous versions
- we have changed our Model `Organizations` name to `Groups` -> generated new app called `groups`
- we thought `is_org_admin` field should be managed by `Groups App` -> deleted from previous `Users App`
## Features
1. Complete `Users App`
   - validate `phonenumber` field
   - user CRUD
   - login / logout / session feature
   - user permission
2. `Groups App`
   - basic `group` modeling
   - MtoN relational mapping ( `User Model` ~ `Groups Model` )
