### PR TITLE
simple modifying about mis-type in settings.py

### DIFF
--- a/buildbuild/buildbuild/settings.py
+++ b/buildbuild/buildbuild/settings.py
@@ -42,7 +42,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 
     # Python Packages
-    'djcelery',
+    'celery',
 
     # Custom Apps
     'users',


### PR DESCRIPTION
simple modifying about mis-type in settings.py

in buildbuild/settings.py,
python packages settings. 
There is a very small mis-type. So I corrected this.
