### PR TITLE
[Sprint #6]added celery always eager option to separate test from celery server & environ password condition

### DIFF
--- a/buildbuild/buildbuild/settings.py
+++ b/buildbuild/buildbuild/settings.py
@@ -10,9 +10,6 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 
 from __future__ import absolute_import
 
-#for celery always eager in settings
-CELERY_ALWAYS_EAGER = True
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -48,6 +45,9 @@ INSTALLED_APPS = (
     'djcelery',
     'djangobower',
     'rest_framework',
+
+    # Kombu transport using the Django database as a message store.
+#    'kombu.transport.django',
 
     # Custom Apps
     'api',
@@ -136,10 +136,13 @@ EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 465  #for submission 
 EMAIL_HOST_USER = "buildbuildteam@gmail.com"
 
+CELERY_ALWAYS_EAGER = True
+
 if "BUILDBUILD_PASSWORD" in os.environ:
     EMAIL_HOST_PASSWORD = os.environ['BUILDBUILD_PASSWORD']
 else:
     EMAIL_HOST_PASSWORD = ""
+
 DEFAULT_FROM_EMAIL = "buildbuild@gmail.com"
 SERVER_EMAIL = "buildbuildteam@gmail.com"
 #DEFAULT_TO_EMAIL = 'to email'

--- a/buildbuild/buildbuild/settings.py
+++ b/buildbuild/buildbuild/settings.py
@@ -10,6 +10,9 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 
 from __future__ import absolute_import
 
+#for celery always eager in settings
+CELERY_ALWAYS_EAGER = True
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -132,7 +135,11 @@ EMAIL_USE_TLS = True
 EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_PORT = 465  #for submission 
 EMAIL_HOST_USER = "buildbuildteam@gmail.com"
-EMAIL_HOST_PASSWORD = os.environ['BUILDBUILD_PASSWORD']
+
+if "BUILDBUILD_PASSWORD" in os.environ:
+    EMAIL_HOST_PASSWORD = os.environ['BUILDBUILD_PASSWORD']
+else:
+    EMAIL_HOST_PASSWORD = ""
 DEFAULT_FROM_EMAIL = "buildbuild@gmail.com"
 SERVER_EMAIL = "buildbuildteam@gmail.com"
 #DEFAULT_TO_EMAIL = 'to email'

--- a/buildbuild/users/tasks.py
+++ b/buildbuild/users/tasks.py
@@ -1,18 +1,18 @@
 from __future__ import absolute_import
 
 from django.core.mail import send_mail
+from django.core import mail
 from django.conf import settings
 from celery import Celery
+from celery import shared_task
 
-users = Celery('users')
-
-@users.task(name="send_mail_to_new_user_using_celery", bind=True)
-def send_mail_to_new_user(self, user):
-    is_send_mail_correctly = send_mail(
+@shared_task
+def send_mail_to_new_user(user):
+    mail.send_mail(
         settings.SUBJECT, 
         settings.CONTENTS, 
         settings.EMAIL_HOST_USER, 
         [user.email], fail_silently=False
         )
-    return is_send_mail_correctly
+    return mail
 

--- a/buildbuild/users/tests/test_send_mail.py
+++ b/buildbuild/users/tests/test_send_mail.py
@@ -17,22 +17,22 @@ class Send_Email_Test(TestCase):
         self.valid_email = "test@example.com"
         self.valid_password = "test_password"
         self.invalid_password = "a"*5
-        self.invalid_host_user = "invalid@gmail.com"
+        self.invalid_email = "invalid@gmail.com"
 
-        # need to find more eloquent way to test redirect url.
-        self.TEST_SERVER_URL = "http://testserver"
+        self.user = User.objects.create_user(
+                email = self.valid_email,
+                password = self.valid_password
+                )
 
-        response = self.client.post("/signup/", {
-            "email": self.valid_email,
-            "password": self.valid_password,
-            })
+    def test_send_mail_to_new_user_using_celery(self):
+        self.assertTrue(tasks.send_mail_to_new_user.delay(self.user))
 
-    def test_send_mail_to_new_user_correctly(self):
+    def test_send_mail_to_new_user(self):
         mail.outbox = []
         mail.send_mail(
                 settings.SUBJECT,
                 settings.CONTENTS,
-                settings.EMAIL_HOST_USER,
+                self.valid_email,
                 [self.valid_email],
                 fail_silently=False
                 )
@@ -43,20 +43,16 @@ class Send_Email_Test(TestCase):
         # Verify that the subject of the first message is correct.
         self.assertEqual(mail.outbox[0].subject, settings.SUBJECT)
 
-    def test_inavalid_host_user_name_cannot_send_mail(self):
+    def test_invalid_email_name_cannot_send_mail(self):
         mail.outbox = []
         mail.send_mail(
                 settings.SUBJECT,
                 settings.CONTENTS,
-                self.invalid_host_user,
+                self.invalid_email,
                 [self.valid_email],
                 fail_silently=False
                 )
                 
         # Test that one message has been sent.
         self.assertEqual(len(mail.outbox), 1)
-
-    def test_send_mail_to_new_user_using_celery(self):
-        mail.outbox = []
-        self.assertTrue(tasks.send_mail_to_new_user.delay())
 

--- a/buildbuild/users/tests/test_signup_page.py
+++ b/buildbuild/users/tests/test_signup_page.py
@@ -20,7 +20,7 @@ class SignUpPageTest(TestCase):
     def test_get_signup_page_request_should_return_200(self):
         response = self.client.get("/signup/")
         self.assertEqual(response.status_code, 200)
-
+    
     def test_check_uniqueness_of_new_user_information_from_signup_page(self):
         User.objects.create_user(self.valid_email, self.valid_password)
 
@@ -31,14 +31,14 @@ class SignUpPageTest(TestCase):
                 })
         except:
             pass
-
+    
     def test_post_signup_page_with_available_new_user_information_should_return_302(self):
         response = self.client.post("/signup/", {
             "email": self.valid_email,
             "password": self.valid_password,
             })
         self.assertEqual(response.status_code, 302)
-
+    
     def test_post_signup_page_with_available_user_information_should_redirect_to_home(self):
         response = self.client.post("/signup/", {
             "email": self.valid_email,
@@ -64,4 +64,4 @@ class SignUpPageTest(TestCase):
     def test_post_signup_page_with_no_user_information_should_have_error_message(self):
         response = self.client.post("/signup/", {})
         self.assertContains(response, "This field is required.")
-
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.6.5
+Django==1.7
 Markdown==2.4.1
 amqp==1.4.6
 anyjson==0.3.3


### PR DESCRIPTION
# 

To seperate celery & test

(I thought that concept continuous ..)

1) Previous test passed because celery server remained in background process.
2) When it is removed (kill -9 instruction) some errors occurred during test process
3) Error name is —>> error: [Errno 61] Connection refused 
4) Therefore celery server is needed to pause when testing
5) In order to do this, we needed to set the variable called CELERY_ALWAYS_EAGER (Task execution option)
6) But error occurred still.
7) The solution was to use @shared_task instead of using @app.task

Because,
8) Celery eager option is available in reusable app
( Or the other way might be possible )
( Note : This option is set in settings.py )
( reusable app means independent app from project )
( the application self-contained and easier to drop into a new project. )
10) @app.task not allowed because of specifying concrete app
11) Therefor, We need to use @shared_tasks module for reusable app
12) The result of the work of celery appear as an eager result object (return)

shared task in celery
http://celery.readthedocs.org/en/latest/django/first-steps-with-django.html#using-the-shared-task-decorator

reusable app
https://docs.djangoproject.com/en/1.7/intro/reusable-apps/#your-project-and-your-reusable-app

eager result class
http://docs.celeryproject.org/en/v2.2.5/reference/celery.result.html#celery.result.EagerResult

blog link
http://soundatrumpet.blogspot.kr/search/label/buildbuild
